### PR TITLE
Fix code scanning alert no. 1: Incorrect conversion between integer types

### DIFF
--- a/internal/bpf/ksym.go
+++ b/internal/bpf/ksym.go
@@ -3,6 +3,7 @@ package bpf
 import (
 	"bufio"
 	"os"
+	"fmt"
 	"sort"
 	"strconv"
 	"strings"
@@ -69,6 +70,9 @@ func ParseKallsyms(funcs Funcs, all bool) (Addr2Name, BpfProgName2Addr, error) {
 			addr, err := strconv.ParseUint(line[0], 16, 64)
 			if err != nil {
 				return a2n, n2a, err
+			}
+			if addr > uint64(^uintptr(0)) {
+				return a2n, n2a, fmt.Errorf("address out of bounds for uintptr: %v", addr)
 			}
 			sym := &ksym{
 				addr: addr,


### PR DESCRIPTION
Fixes [https://github.com/cen-ngc5139/nfs-trace/security/code-scanning/1](https://github.com/cen-ngc5139/nfs-trace/security/code-scanning/1)

To fix the problem, we need to ensure that the `uint64` value parsed from the string is within the bounds of the `uintptr` type before performing the conversion. This can be done by adding an upper bound check to ensure the value does not exceed the maximum value that `uintptr` can hold.

1. Use the `math` package to get the maximum value for `uintptr`.
2. Add a check to ensure the parsed `uint64` value is within the bounds of `uintptr`.
3. If the value is out of bounds, handle the error appropriately (e.g., by returning an error or using a default value).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
